### PR TITLE
카드 수정,삭제 관련 refactor (함수 권한 변경)

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -6,15 +6,15 @@ import EditCardForm from "./EditCardForm";
 import jsonLocalStorage from "../utils/jsonLocalStorage";
 
 const Board = ({ children, cardId,updateCardId,type }) => {
-  const [createMode, setCreateMode] = useState(false);
+  const [isCreate, setIsCreate] = useState(false);
   const [cards, setCards] = useState(jsonLocalStorage.getItem(type) || []);
-  const [editedCard, setEditedCard] = useState(null);
+
   const handleCancelBtnClick = () => {
-    setCreateMode(false);
+    setIsCreate(false);
   }; 
   
   const handlePlusBtnClick = () => {
-    setCreateMode(true);
+    setIsCreate(true);
   };
 
   const handleFormSubmit = (e) => {
@@ -26,17 +26,10 @@ const Board = ({ children, cardId,updateCardId,type }) => {
   };
   
  
-  const onUpdate = (_title, _body) => {
-    let nextCards = cards.filter(card=>card.id!==editedCard.id);
-    nextCards = nextCards.concat({ id: editedCard.id, title: _title, body: _body })
-    setCards(nextCards);
-    jsonLocalStorage.setItem(type, nextCards);
-  };
- 
   return (
     <div className="board">
       <h2 className="boardTitle">{children}</h2>
-      <div>
+ 
         {cards.map((card,idx) => (
           <Card
             key={idx}
@@ -46,8 +39,8 @@ const Board = ({ children, cardId,updateCardId,type }) => {
             setCards={setCards}
           />
         ))}
-      </div>
-      {createMode&&(<NewCardForm
+
+      {isCreate&&(<NewCardForm
       onCancelBtnClick={handleCancelBtnClick}
       handleFormSubmit={handleFormSubmit}
     />)}

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -19,10 +19,10 @@ const Board = ({ children, cardId,updateCardId,type }) => {
 
   const handleFormSubmit = (e) => {
     e.preventDefault();
-    const nextCards = [...cards, { id: cardId.current, title: e.target.title.value, body: e.target.body.value}];
+    const nextCards = [...cards, { cardId: cardId.current, title: e.target.title.value, body: e.target.body.value}];
     setCards(nextCards);
-    jsonLocalStorage.setItem(type, nextCards);
     updateCardId();
+    jsonLocalStorage.setItem(type, nextCards);
   };
   
  
@@ -31,25 +31,7 @@ const Board = ({ children, cardId,updateCardId,type }) => {
     nextCards = nextCards.concat({ id: editedCard.id, title: _title, body: _body })
     setCards(nextCards);
     jsonLocalStorage.setItem(type, nextCards);
-    // setCardForm(null);
   };
-
-  const handleCloseBtnClick = (cardId) => {
-    const nextCards = cards.filter(card=>card.id !==cardId);
-    setCards(nextCards);
-    jsonLocalStorage.setItem(type, nextCards);
-  };
-
-  const handleEditBtnClick = (cardId) => {
-    const selectedCard = cards.find((card) => card.id === cardId);
-    // setCardForm(<EditCardForm
-    //   onCancelBtnClick={handleCancelBtnClick}
-    //   editedCard={editedCard}
-    //   onUpdate={onUpdate}
-    // />);
-    setEditedCard(selectedCard);
-  };
-
  
   return (
     <div className="board">
@@ -58,10 +40,7 @@ const Board = ({ children, cardId,updateCardId,type }) => {
         {cards.map((card,idx) => (
           <Card
             key={idx}
-            work={card}
-            handleCloseBtnClick={handleCloseBtnClick}
-            handleEditBtnClick={handleEditBtnClick}
-            // handleMoveBtnClick={handleMoveBtnClick}
+            card={card}
             type={type}
             cards={cards} 
             setCards={setCards}

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -5,41 +5,33 @@ import NewCardForm from "./NewCardForm";
 import EditCardForm from "./EditCardForm";
 import jsonLocalStorage from "../utils/jsonLocalStorage";
 
-const Board = ({ children, type, handleMoveBtnClick }) => {
-  const [cardForm, setCardForm] = useState("");
+const Board = ({ children, cardId,updateCardId,type }) => {
+  const [createMode, setCreateMode] = useState(false);
   const [cards, setCards] = useState(jsonLocalStorage.getItem(type) || []);
-  const [id, setId] = useState(0);
   const [editedCard, setEditedCard] = useState(null);
-
-  const handlePlusBtnClick = () => {
-    setCardForm(<NewCardForm
-      onCancelBtnClick={handleCancelBtnClick}
-      onSubmit={handleFormSubmit}
-    />);
-  };
-
   const handleCancelBtnClick = () => {
-    setCardForm(null);
-  };
+    setCreateMode(false);
+  }; 
   
+  const handlePlusBtnClick = () => {
+    setCreateMode(true);
+  };
+
   const handleFormSubmit = (e) => {
     e.preventDefault();
-    const _title = e.target.title.value;
-    const _body = e.target.body.value;
-    const newCard = { id: id, title: _title, body: _body };
-    const nextCards = [...cards, newCard];
-
+    const nextCards = [...cards, { id: cardId.current, title: e.target.title.value, body: e.target.body.value}];
     setCards(nextCards);
     jsonLocalStorage.setItem(type, nextCards);
-    setId(id + 1);
+    updateCardId();
   };
-
+  
+ 
   const onUpdate = (_title, _body) => {
     let nextCards = cards.filter(card=>card.id!==editedCard.id);
     nextCards = nextCards.concat({ id: editedCard.id, title: _title, body: _body })
     setCards(nextCards);
     jsonLocalStorage.setItem(type, nextCards);
-    setCardForm(null);
+    // setCardForm(null);
   };
 
   const handleCloseBtnClick = (cardId) => {
@@ -50,31 +42,37 @@ const Board = ({ children, type, handleMoveBtnClick }) => {
 
   const handleEditBtnClick = (cardId) => {
     const selectedCard = cards.find((card) => card.id === cardId);
-    setCardForm(<EditCardForm
-      onCancelBtnClick={handleCancelBtnClick}
-      editedCard={editedCard}
-      onUpdate={onUpdate}
-    />);
+    // setCardForm(<EditCardForm
+    //   onCancelBtnClick={handleCancelBtnClick}
+    //   editedCard={editedCard}
+    //   onUpdate={onUpdate}
+    // />);
     setEditedCard(selectedCard);
   };
 
-
+ 
   return (
     <div className="board">
       <h2 className="boardTitle">{children}</h2>
       <div>
-        {cards.map((card) => (
+        {cards.map((card,idx) => (
           <Card
-            id={card.id}
+            key={idx}
             work={card}
             handleCloseBtnClick={handleCloseBtnClick}
             handleEditBtnClick={handleEditBtnClick}
-            handleMoveBtnClick={handleMoveBtnClick}
+            // handleMoveBtnClick={handleMoveBtnClick}
             type={type}
+            cards={cards} 
+            setCards={setCards}
           />
         ))}
       </div>
-      {cardForm}
+      {createMode&&(<NewCardForm
+      onCancelBtnClick={handleCancelBtnClick}
+      handleFormSubmit={handleFormSubmit}
+    />)}
+    
       <button onClick={handlePlusBtnClick}>+</button>
     </div>
   );

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,29 +1,71 @@
 import "../scss/Card.scss";
+import "../scss/EditCardForm.scss";
 import closeIcon from "../assets/close.svg";
 import editIcon from "../assets/edit.svg";
 import jsonLocalStorage from "../utils/jsonLocalStorage";
+import { useState } from "react";
 
-const Card= ({card,cards,setCards,type,}) => {
+const Card= ({card,cards,setCards,type}) => {
+    const [isEdit,setIsEdit] = useState(false);
+    const [title, setTitle] = useState(card.title);
+    const [body, setBody] = useState(card.body);
 
-    const handleCloseBtnClick = () => {
+    const handleRemoveBtnClick = () => {
       const nextCards = cards.filter(e=>e.cardId !==card.cardId);
       setCards(nextCards);
       jsonLocalStorage.setItem(type, nextCards);
     };
 
-    // const handleEditBtnClick = () => {
-    //   const selectedCard = cards.find(e=>e.cardId ===card.cardId);
-    //   setEditedCard(selectedCard);
-    // };
+    const handleEditSubmit = (e) => {
+      e.preventDefault();
+      let nextCards = cards.filter(e=>e.cardId !==card.cardId);
+      nextCards = nextCards.concat({ cardId: card.cardid, title: title, body: body })
+      setCards(nextCards);
+      jsonLocalStorage.setItem(type, nextCards);
+      setIsEdit(false);
+    };
 
-  return (
+    const handleEditBtnClick = () => {
+      setIsEdit(true);
+    };
+
+    const handleEditCancelBtnClick = () => {
+      setIsEdit(false);
+    }; 
+
+  return <>
+  {isEdit?
+    <form className="editCardForm" onSubmit={handleEditSubmit}>
+    <div className="colors">
+    </div>
+    <input
+      className="editInputTitle"
+      placeholder="해야할 일을 입력하세요."
+      name="title"
+      value={title}
+      onChange={(e) => {
+        setTitle(e.target.value);
+      }}
+    />
+    <textarea
+      className="editInputBody"
+      placeholder="자세히 입력해주세요."
+      name="body"
+      value={body}
+      onChange={(e) => {
+        setBody(e.target.value);
+      }}
+    />
+    <button type="submit" >수정완료</button>
+    <button onClick={handleEditCancelBtnClick}>취소</button>
+  </form>
+  :
     <div className="card">
       <div className="cardBtns">
-      {/* <button onClick={handleEditBtnClick}> */}
-      <button>
+      <button onClick={handleEditBtnClick}>
           <img src={editIcon} alt="X"></img>
         </button>
-        <button onClick={handleCloseBtnClick}>
+        <button onClick={handleRemoveBtnClick}>
           <img src={closeIcon} alt="X"></img>
         </button>
       </div>
@@ -48,8 +90,8 @@ const Card= ({card,cards,setCards,type,}) => {
       </div>
 
       {card.body ? <div className="cardBody">{card.body}</div> : null}
-    </div>
-  );
+    </div>}
+    </>
 };
 
 export default Card;

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,52 +1,53 @@
 import "../scss/Card.scss";
 import closeIcon from "../assets/close.svg";
 import editIcon from "../assets/edit.svg";
+import jsonLocalStorage from "../utils/jsonLocalStorage";
 
-const Card= ({
-  work,
-  handleCloseBtnClick,
-  handleEditBtnClick,
-  handleMoveBtnClick,
-  type,
-  // handleLocalStorageChange,
-}) => {
-  const id = work.id;
-  // const handleBtn = (id, type, str) => {
-  //   handleLocalStorageChange();
-  //   handleMoveBtnClick(id, type, str);
-  // };
+const Card= ({card,cards,setCards,type,}) => {
+
+    const handleCloseBtnClick = () => {
+      const nextCards = cards.filter(e=>e.cardId !==card.cardId);
+      setCards(nextCards);
+      jsonLocalStorage.setItem(type, nextCards);
+    };
+
+    // const handleEditBtnClick = () => {
+    //   const selectedCard = cards.find(e=>e.cardId ===card.cardId);
+    //   setEditedCard(selectedCard);
+    // };
 
   return (
     <div className="card">
       <div className="cardBtns">
-      <button onClick={() => handleEditBtnClick(id)}>
+      {/* <button onClick={handleEditBtnClick}> */}
+      <button>
           <img src={editIcon} alt="X"></img>
         </button>
-        <button onClick={() => handleCloseBtnClick(id)}>
+        <button onClick={handleCloseBtnClick}>
           <img src={closeIcon} alt="X"></img>
         </button>
       </div>
-      <h3 className="cardTitle">{work.title}</h3>
+      <h3 className="cardTitle">{card.title}</h3>
       <div
         className="moveTodo"
-        onClick={() => handleMoveBtnClick(id, type, "toDo")}
+        // onClick={() => handleMoveBtnClick(id, type, "toDo")}
       >
         🐣
       </div>
       <div
         className="moveProgress"
-        onClick={() => handleMoveBtnClick(id, type, "inProgress")}
+        // onClick={() => handleMoveBtnClick(id, type, "inProgress")}
       >
         🐥
       </div>
       <div
         className="moveDone"
-        onClick={() => handleMoveBtnClick(id, type, "done")}
+        // onClick={() => handleMoveBtnClick(id, type, "done")}
       >
         🦅
       </div>
 
-      {work.body ? <div className="cardBody">{work.body}</div> : null}
+      {card.body ? <div className="cardBody">{card.body}</div> : null}
     </div>
   );
 };

--- a/src/components/NewCardForm.jsx
+++ b/src/components/NewCardForm.jsx
@@ -1,6 +1,6 @@
 import '../scss/NewCardForm.scss';
 
-const NewCardForm = ({ onCancelBtnClick,handleFormSubmit,type }) => {
+const NewCardForm = ({ onCancelBtnClick,handleFormSubmit}) => {
 
   return (
     <form className="newCardForm" onSubmit={handleFormSubmit}>

--- a/src/components/NewCardForm.jsx
+++ b/src/components/NewCardForm.jsx
@@ -1,8 +1,9 @@
 import '../scss/NewCardForm.scss';
 
-const NewCardForm = ({ onSubmit, onCancelBtnClick }) => {
+const NewCardForm = ({ onCancelBtnClick,handleFormSubmit,type }) => {
+
   return (
-    <form className="newCardForm" onSubmit={onSubmit}>
+    <form className="newCardForm" onSubmit={handleFormSubmit}>
       <div className="colors">
         <div></div>
       </div>

--- a/src/components/Template.jsx
+++ b/src/components/Template.jsx
@@ -1,39 +1,27 @@
 import "../scss/Template.scss";
 import jsonLocalStorage from "../utils/jsonLocalStorage";
 import Board from "./Board";
-import { useState } from "react";
+import { useRef } from "react";
 
-const Template = ({ children }) => {
-  const [startItems, setStartItems] = useState([]);
-  const [endItems, setEndItems] = useState([]);
+const Template = () => {
+  const cardId = useRef(0);
   const boards = [
     {title:"To do 🐣",type:"toDo"},
     {title:"In Progress 🐥",type:"inProgress"},
     {title:"Done 🦅",type:"done"},
   ];
 
-  const handleMoveBtnClick = (id, start, end) => {
-    setStartItems(jsonLocalStorage.getItem(start));
-    setEndItems(jsonLocalStorage.getItem(end));
+  const updateCardId = () => {
+    cardId.current++;
+  }
 
-    const movedItem = jsonLocalStorage
-      .getItem(start)
-      .find((item) => item.id === id);
 
-    const newEndItems = [...endItems, movedItem];
-    setEndItems(newEndItems);
-    jsonLocalStorage.setItem(end, newEndItems);
-
-    const newStartItems = startItems.filter((item) => item.id !== id);
-    setStartItems(newStartItems);
-    jsonLocalStorage.setItem(start, newStartItems);
-  };
 
   return (
     <div className="template">
       <h1 className="title">RoadMap</h1>
       <div className="content">
-        {boards.map(board=><Board type={board.type} handleMoveBtnClick={handleMoveBtnClick}>{board.title}</Board>)}
+        {boards.map((board,idx)=><Board key={idx} type={board.type} cardId={cardId} updateCardId={updateCardId}>{board.title}</Board>)}
       </div>
     </div>
   );


### PR DESCRIPTION
# 변경사항

### 1. Template이 cardId를 관리하도록 변경
  - (기존) Card를 만들면 Boad에서 cardId를 관리
  - (현재) Card 만들면 Template에서cardId를 관리 (useRef 사용)
  - (의도) 3개의 Board가 cardId를 공유하도록 하려고.
  
### 2. 삭제 기능 함수를 Card에서 정의
   - (기존) 삭제기능 `handleCloseBtnClick` 을 Board에서 정의하고 Card로 props로 넘김
   -  (현재) 삭제기능 정의와 호출을 모두 Card에서 함.
   -  (의도)
      - (기존) Board에 포함된 card들의 `배열` 을 삭제함수에서 사용해야 하기 때문에, Board에서 정의해야한다고 생각.
      - (현재) 만약 Card에 다른 기능이 추가된다면 Board에서 Card로 넘겨야하는 props가 증가하는 문제. => Board에서 `배열` 을 Card에 넘기고 함수 정의, 호출을 모두 Card에서 하는걸로 변경

### 3. 수정 기능 함수를 Card에서 정의
  -  `2. 삭제 기능 함수를 Card에서 정의`  와 동일한 과정을 `handleEditBtnClick` ,`handleEditSubmit`  에 대해서 수행

### 4. 카드 수정시 UI를 수정
  -  (기존) 수정 버튼 클릭시 Card 수정을 Board 아래에서 수행
  -  (현재) 토글되도록 변경


# 버그
  - ` 4. 카드 수정시 UI를 수정` 에서 토글 될 때 UI가 어긋남
    - 위치가 맞지 않음.
    - 정렬 상태가 이상함
